### PR TITLE
fix: various gradle build problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ bin/
 .classpath
 .project
 build/
+directory-app/src/main/resources/
 db/
 Lucene/

--- a/directory-core/build.gradle
+++ b/directory-core/build.gradle
@@ -25,6 +25,7 @@ repositories {
 dependencies {
 	compile 'org.eclipse.rdf4j:rdf4j-runtime:2.2.4'
 	compile 'com.github.jsonld-java:jsonld-java:0.12.0'
+        compile 'commons-lang:commons-lang:2.6'
 	
 	compile 'org.codehaus.groovy:groovy:3.0.0-alpha-2'
 	compile 'org.codehaus.groovy:groovy-json:3.0.0-alpha-2'

--- a/directory-servlet/build.gradle
+++ b/directory-servlet/build.gradle
@@ -27,8 +27,8 @@ repositories {
 dependencies {
 	compile project(':directory-core')
 	
-	compile 'javax.servlet:servlet-api:2.5'
-	
+	compile 'javax.servlet:javax.servlet-api:3.1.0'
+
 	testCompile 'junit:junit:4.8'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
directory-core: add missing dependency to commons-lang
directory-servlet: update dependency to javax.servlet to avoid version mix
gradle wrapper: update gradle version to allow build with current Java versions (10, 11)
.gitignore: ignore directory-app/src/main/resources/ created during build

Signed-off-by: Martin Winter <martin.winter@siemens.com>